### PR TITLE
Update readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,7 +28,26 @@ cookiecutter https://github.com/cicwi/cookiecutter-cicwi.git
 #+END_SRC
 
 Then:
-1. Answer the questions that cookiecutter asks
+1. Answer the questions that cookiecutter asks, for instance
+   #+BEGIN_EXAMPLE
+   $ cookiecutter gh:cicwi/cookiecutter-cicwi
+   You've downloaded /ufs/hendriks/.cookiecutters/cookiecutter-cicwi before. Is it okay to delete and re-download it? [yes]: yes
+   full_name [Your Name]: Allard Hendriksen
+   email [example@example.com]: allard.hendriksen@cwi.nl
+   github_username [cicwi]: ahendriksen
+   project_name [Human readable project name]: Cone Balls
+   project_slug [cone_balls]:
+   project_short_description [Python CI CWI boilerplate package.]: A package for bubble phantom generation using a cone beam CT geometry.
+   version [0.1.0]:
+   use_pytest [n]:
+   Select open_source_license:
+   1 - GNU General Public License v3
+   2 - Apache Software License 2.0
+   3 - Not open source
+   Choose from 1, 2, 3 [1]: 1
+   #+END_EXAMPLE
+   Note that =slug= means a project name without spaces that is usable
+   as directory name and GitHub project name.
 2. =cd new-project=
 3. =git init=
 4. Install development requirements

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -94,5 +94,6 @@ install_dev:
 	# https://stackoverflow.com/a/28842733
 	pip install -e .[dev]
 
-conda_package: install_dev
+conda_package:
+	conda install conda-build -y
 	conda build conda/

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -73,7 +73,10 @@ coverage: ## check code coverage quickly with the default Python
 	coverage html
 	$(BROWSER) htmlcov/index.html
 
-docs: install_dev## generate Sphinx HTML documentation, including API docs
+docs/.nojekyll:
+	touch docs/.nojekyll
+
+docs: docs/.nojekyll install_dev ## generate Sphinx HTML documentation, including API docs
 	rm -f doc_sources/{{ cookiecutter.project_slug }}.rst
 	rm -f doc_sources/modules.rst
 	sphinx-apidoc -o doc_sources/ {{ cookiecutter.project_slug }}

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -8,6 +8,47 @@
 * Documentation: [https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug }}]
 {% endif %}
 
+## Readiness
+
+The author of this package is in the process of setting up this
+package for optimal usability. The following has already been completed:
+
+- [ ] Documentation
+    - Documentation has been generated using `make docs`, committed,
+        and pushed to GitHub.
+	- GitHub pages have been setup in the project
+      (Settings)[/settings] with "master branch /docs folder".
+- [ ] An initial release
+	- In `CHANGELOG.md`, a release date has been added to v0.1.0 (change the YYYY-MM-DD).
+	- The release has been marked a release on GitHub.
+	- For more info, see the [Software Release Guide](https://cicwi.github.io/software-guidelines/software-release-guide).
+- [ ] A conda package
+	- Required packages have been added to `setup.py`, for instance,
+	  ```
+	  requirements = [ ]
+	  ```
+	  Has been replaced by
+	  ```
+	  requirements = [
+	      'sacred>=0.7.2'
+      ]
+      ```
+	- All "conda channels" that are required for building and
+      installing the package have been added to the
+      `Makefile`. Specifically, replace
+	  ```
+      conda_package: install_dev
+      	conda build conda/
+      ```
+	  by
+	  ```
+      conda_package: install_dev
+      	conda build conda/ -c some-channel -c some-other-channel
+      ```
+    - Conda packages have been built successfully with `make conda_package`.
+	- These conda packages have been uploaded to [Anaconda](https://anaconda.org).
+	- The installation instructions (below) have been updated.
+
 ## Getting Started
 
 It takes a few steps to setup {{ cookiecutter.project_name }} on your

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -16,8 +16,8 @@ package for optimal usability. The following has already been completed:
 - [ ] Documentation
     - Documentation has been generated using `make docs`, committed,
         and pushed to GitHub.
-	- GitHub pages have been setup in the project
-      [Settings](/settings) with "master branch /docs folder".
+	- GitHub pages have been setup in the project settings
+	  with the "source" set to "master branch /docs folder".
 - [ ] An initial release
 	- In `CHANGELOG.md`, a release date has been added to v0.1.0 (change the YYYY-MM-DD).
 	- The release has been marked a release on GitHub.

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -17,7 +17,7 @@ package for optimal usability. The following has already been completed:
     - Documentation has been generated using `make docs`, committed,
         and pushed to GitHub.
 	- GitHub pages have been setup in the project
-      (Settings)[/settings] with "master branch /docs folder".
+      [Settings](/settings) with "master branch /docs folder".
 - [ ] An initial release
 	- In `CHANGELOG.md`, a release date has been added to v0.1.0 (change the YYYY-MM-DD).
 	- The release has been marked a release on GitHub.


### PR DESCRIPTION
This PR improves:
1) This project's README
2) The templated project's README
 - Includes a checklist for the project's owner to get documentation and packaging under way. 
3) Fixes the templated project's Makefile
  - The documentation now has a `.nojekyll` file. This fixes the gh-pages integration. 
  - The conda_package Make command installs conda-build automatically.